### PR TITLE
Handle templates embedded in script tags (WIP)

### DIFF
--- a/META-INF/plugin.xml
+++ b/META-INF/plugin.xml
@@ -177,5 +177,6 @@
     <applicationConfigurable instance="com.dmarcotte.handlebars.pages.HbConfigurationPage"/>
     <codeFoldingOptionsProvider
         instance="com.dmarcotte.handlebars.config.HbFoldingOptionsProvider" />
+    <lang.syntaxHighlighterFactory key="Handlebars" implementationClass="com.dmarcotte.handlebars.HbHighlighterFactory"/>
   </extensions>
 </idea-plugin>

--- a/src/com/dmarcotte/handlebars/HbHighlighterFactory.java
+++ b/src/com/dmarcotte/handlebars/HbHighlighterFactory.java
@@ -1,0 +1,13 @@
+package com.dmarcotte.handlebars;
+
+import com.intellij.openapi.fileTypes.SingleLazyInstanceSyntaxHighlighterFactory;
+import com.intellij.openapi.fileTypes.SyntaxHighlighter;
+import org.jetbrains.annotations.NotNull;
+
+public class HbHighlighterFactory extends SingleLazyInstanceSyntaxHighlighterFactory {
+    @NotNull
+    @Override
+    protected SyntaxHighlighter createHighlighter() {
+        return new HbHighlighter();
+    }
+}

--- a/src/com/dmarcotte/handlebars/HbLanguage.java
+++ b/src/com/dmarcotte/handlebars/HbLanguage.java
@@ -1,11 +1,12 @@
 package com.dmarcotte.handlebars;
 
+import com.intellij.lang.InjectableLanguage;
 import com.intellij.lang.Language;
 import com.intellij.openapi.fileTypes.LanguageFileType;
 import com.intellij.openapi.fileTypes.StdFileTypes;
 import com.intellij.psi.templateLanguages.TemplateLanguage;
 
-public class HbLanguage extends Language implements TemplateLanguage {
+public class HbLanguage extends Language implements TemplateLanguage, InjectableLanguage {
     public static final HbLanguage INSTANCE = new HbLanguage();
 
     @SuppressWarnings ("SameReturnValue") // ideally this would be public static, but the static inits in the tests get cranky when we do that

--- a/src/com/dmarcotte/handlebars/editor/actions/HbTypedHandler.java
+++ b/src/com/dmarcotte/handlebars/editor/actions/HbTypedHandler.java
@@ -2,7 +2,6 @@ package com.dmarcotte.handlebars.editor.actions;
 
 import com.dmarcotte.handlebars.HbLanguage;
 import com.dmarcotte.handlebars.config.HbConfig;
-import com.dmarcotte.handlebars.file.HbFileViewProvider;
 import com.dmarcotte.handlebars.parsing.HbTokenTypes;
 import com.dmarcotte.handlebars.psi.HbPsiElement;
 import com.dmarcotte.handlebars.psi.HbPsiUtil;
@@ -36,7 +35,7 @@ public class HbTypedHandler extends TypedHandlerDelegate {
 
         String previousChar = editor.getDocument().getText(new TextRange(offset - 1, offset));
 
-        if (file.getViewProvider() instanceof HbFileViewProvider) {
+        if (file.getViewProvider().getBaseLanguage() instanceof HbLanguage) {
             PsiDocumentManager.getInstance(project).commitAllDocuments();
 
             // we suppress the built-in "}" auto-complete when we see "{{"
@@ -67,7 +66,7 @@ public class HbTypedHandler extends TypedHandlerDelegate {
 
         String previousChar = editor.getDocument().getText(new TextRange(offset - 2, offset - 1));
 
-        if (file.getViewProvider() instanceof HbFileViewProvider) {
+        if (provider.getBaseLanguage() instanceof HbLanguage) {
             // if we're looking at a close stache, we may have some business too attend to
             if (c == '}' && previousChar.equals("}")) {
                 autoInsertCloseTag(project, offset, editor, provider);


### PR DESCRIPTION
Templates which are inlined in an html page can be pretty handy, so let's get the plugin working for them...

The Handlebars docs suggest embedding templates in script tags of type text/x-handlebars-template, so we should support that use case by default, but also ensure that the Handlebars lang definition allows users to inject it where ever they want using Settings->Language Injection.

Note: The current implementation of this relies on the the IntelliLang plugin being installed (it is part of the default plugin bundle, so it probably will be for most users).
