### PR TITLE
Remove reference to problematic BorderFactory class

### DIFF
--- a/src/com/dmarcotte/handlebars/pages/HbConfigurationPage.form
+++ b/src/com/dmarcotte/handlebars/pages/HbConfigurationPage.form
@@ -8,32 +8,19 @@
     <properties/>
     <border type="none"/>
     <children>
-      <grid id="25712" layout-manager="GridLayoutManager" row-count="1" column-count="1" same-size-horizontally="false" same-size-vertically="false" hgap="-1" vgap="-1">
-        <margin top="0" left="0" bottom="0" right="0"/>
-        <constraints>
-          <grid row="0" column="0" row-span="1" col-span="1" vsize-policy="3" hsize-policy="3" anchor="0" fill="3" indent="0" use-parent-layout="false"/>
-        </constraints>
-        <properties/>
-        <clientProperties>
-          <BorderFactoryClass class="java.lang.String" value="com.intellij.ui.IdeBorderFactory$BoldSmallWithIndent"/>
-        </clientProperties>
-        <border type="none" title="Handlebars"/>
-        <children>
-          <component id="c59a3" class="javax.swing.JCheckBox" binding="myAutoGenerateClosingTagCheckBox">
-            <constraints>
-              <grid row="0" column="0" row-span="1" col-span="1" vsize-policy="0" hsize-policy="3" anchor="8" fill="0" indent="0" use-parent-layout="false"/>
-            </constraints>
-            <properties>
-              <text resource-bundle="messages/HbBundle" key="hb.pages.options.generate.closing.tag"/>
-            </properties>
-          </component>
-        </children>
-      </grid>
       <vspacer id="837b7">
         <constraints>
           <grid row="1" column="0" row-span="1" col-span="1" vsize-policy="6" hsize-policy="1" anchor="0" fill="2" indent="0" use-parent-layout="false"/>
         </constraints>
       </vspacer>
+      <component id="c59a3" class="javax.swing.JCheckBox" binding="myAutoGenerateClosingTagCheckBox">
+        <constraints>
+          <grid row="0" column="0" row-span="1" col-span="1" vsize-policy="0" hsize-policy="3" anchor="8" fill="0" indent="0" use-parent-layout="false"/>
+        </constraints>
+        <properties>
+          <text resource-bundle="messages/HbBundle" key="hb.pages.options.generate.closing.tag"/>
+        </properties>
+      </component>
     </children>
   </grid>
 </form>


### PR DESCRIPTION
com.intellij.ui.IdeBorderFactory$BoldSmallWithIndent is apparently no longer packaged with the latest versions of IDEA products.  Simplify the Handlebars configuration page to remove this border.

This pull fixes issue #13.
