### PR TITLE
Fix issue in EnterHandler and refactor ActionHandler tests

### DIFF
--- a/META-INF/plugin.xml
+++ b/META-INF/plugin.xml
@@ -104,7 +104,7 @@
     <lang.commenter language="Handlebars" implementationClass="com.dmarcotte.handlebars.HandlebarsCommenter"/>
     <lang.braceMatcher language="Handlebars" implementationClass="com.dmarcotte.handlebars.HbBraceMatcher"/>
     <typedHandler implementation="com.dmarcotte.handlebars.editor.actions.HbTypedHandler"/>
-    <enterHandlerDelegate implementation="com.dmarcotte.handlebars.editor.actions.HbEnterBetweenTagsHandler"/>
+    <enterHandlerDelegate implementation="com.dmarcotte.handlebars.editor.actions.HbEnterHandler"/>
     <applicationConfigurable instance="com.dmarcotte.handlebars.pages.HbConfigurationPage"/>
   </extensions>
 </idea-plugin>

--- a/src/com/dmarcotte/handlebars/editor/actions/HbEnterHandler.java
+++ b/src/com/dmarcotte/handlebars/editor/actions/HbEnterHandler.java
@@ -14,16 +14,35 @@ import com.intellij.psi.PsiElement;
 import com.intellij.psi.PsiFile;
 import org.jetbrains.annotations.NotNull;
 
-public class HbEnterBetweenTagsHandler extends EnterHandlerDelegateAdapter {
+/**
+ * Handler for custom plugin actions when {@code Enter} is typed by the user
+ */
+public class HbEnterHandler extends EnterHandlerDelegateAdapter {
+
     public Result preprocessEnter(@NotNull final PsiFile file, @NotNull final Editor editor, @NotNull final Ref<Integer> caretOffset, @NotNull final Ref<Integer> caretAdvance,
                                   @NotNull final DataContext dataContext, final EditorActionHandler originalHandler) {
-        if (file instanceof HbPsiFile && isBetweenHbTags(editor, file, caretOffset.get())) {
+        /**
+         * if we are between open and close tags, we ensure the caret ends up in the "logical" place on Enter.
+         * i.e. "{{#foo}}<caret>{{/foo}}" becomes the following on Enter:
+         *
+         * {{#foo}}
+         * <caret>
+         * {{/foo}}
+         *
+         * (Note: <caret> may be indented depending on formatter settings.)
+         */
+        if (file instanceof HbPsiFile
+                && isBetweenHbTags(editor, file, caretOffset.get())) {
             originalHandler.execute(editor, dataContext);
-            return Result.DefaultForceIndent;
+            return Result.Default;
         }
         return Result.Continue;
     }
 
+    /**
+     * Checks to see if {@code Enter} has been typed while the caret is between an open and close tag pair.
+     * @return true if between open and close tags, false otherwise
+     */
     private static boolean isBetweenHbTags(Editor editor, PsiFile file, int offset) {
         if (offset == 0) return false;
         CharSequence chars = editor.getDocument().getCharsSequence();
@@ -41,6 +60,11 @@ public class HbEnterBetweenTagsHandler extends EnterHandlerDelegateAdapter {
         }
 
         iterator.advance();
+
+        if (iterator.atEnd()) {
+            // no more tokens, so certainly no close tag
+            return false;
+        }
 
         final PsiElement closerElement = file.findElementAt(iterator.getStart());
 

--- a/src/com/dmarcotte/handlebars/editor/actions/HbTypedHandler.java
+++ b/src/com/dmarcotte/handlebars/editor/actions/HbTypedHandler.java
@@ -17,6 +17,10 @@ import com.intellij.psi.PsiElement;
 import com.intellij.psi.PsiFile;
 import org.jetbrains.annotations.NotNull;
 
+/**
+ * Handler for custom plugin actions on chars typed by the user.  See {@link HbEnterHandler} for custom actions
+ * on Enter.
+ */
 public class HbTypedHandler extends TypedHandlerDelegate {
     @Override
     public Result beforeCharTyped(char c, Project project, Editor editor, PsiFile file, FileType fileType) {

--- a/test/src/com/dmarcotte/handlebars/editor/actions/HbActionHandlerTest.java
+++ b/test/src/com/dmarcotte/handlebars/editor/actions/HbActionHandlerTest.java
@@ -1,0 +1,98 @@
+package com.dmarcotte.handlebars.editor.actions;
+
+import com.dmarcotte.handlebars.file.HbFileType;
+import com.intellij.openapi.actionSystem.IdeActions;
+import com.intellij.openapi.application.ApplicationManager;
+import com.intellij.openapi.command.CommandProcessor;
+import com.intellij.openapi.editor.actionSystem.EditorActionHandler;
+import com.intellij.openapi.editor.actionSystem.EditorActionManager;
+import com.intellij.openapi.editor.actionSystem.TypedAction;
+import com.intellij.openapi.editor.ex.EditorEx;
+import com.intellij.openapi.project.Project;
+import com.intellij.testFramework.fixtures.LightPlatformCodeInsightFixtureTestCase;
+import org.jetbrains.annotations.NotNull;
+
+/**
+ * Base test for plugin action handlers
+ */
+public abstract class HbActionHandlerTest extends LightPlatformCodeInsightFixtureTestCase {
+    private String myPrevPlatformPrefix;
+
+    private void performWriteAction(final Project project, final Runnable action) {
+        ApplicationManager.getApplication().runWriteAction(new Runnable() {
+            @Override
+            public void run() {
+                CommandProcessor.getInstance().executeCommand(project, action, "test command", null);
+            }
+        });
+    }
+
+    @Override
+    protected void setUp() throws Exception {
+        // this test's parent setup requires that this property be set
+        myPrevPlatformPrefix = System.getProperty("idea.platform.prefix");
+        System.setProperty("idea.platform.prefix", "Idea");
+
+        super.setUp();
+    }
+
+    @Override
+    protected void tearDown() throws Exception {
+        if (myPrevPlatformPrefix == null) {
+            System.setProperty("idea.platform.prefix", "");
+        } else {
+            System.setProperty("idea.platform.prefix", myPrevPlatformPrefix);
+        }
+        super.tearDown();
+    }
+
+    private void validateTestStrings(@NotNull String before, @NotNull String expected) {
+        if (!before.contains("<caret>")
+                || !expected.contains("<caret>")) {
+            throw new IllegalArgumentException("Test strings must contain \"<caret>\" to indicate caret position");
+        }
+    }
+
+    /**
+     * Call this method to test behavior when the given char c is typed.  Use the String {@code "<caret>"} in your
+     * 'before' and 'expected' arguments to indicate the position of the caret in those strings.
+     *
+     * @param c The character to type
+     * @param before The text before the character is typed, with substring "<caret>" to indicate the position of the caret
+     * @param expected The text expected after the character is typed, with substring "<caret>" to indicate the position of the caret
+     */
+    protected void doCharTest(final char c, @NotNull String before, @NotNull String expected) {
+        validateTestStrings(before, expected);
+
+        myFixture.configureByText(HbFileType.INSTANCE, before);
+        final TypedAction typedAction = EditorActionManager.getInstance().getTypedAction();
+        performWriteAction(myFixture.getProject(), new Runnable() {
+            @Override
+            public void run() {
+                typedAction.actionPerformed(myFixture.getEditor(), c, ((EditorEx) myFixture.getEditor()).getDataContext());
+            }
+        });
+        myFixture.checkResult(expected);
+    }
+
+    /**
+     * Call this method to test behavior when Enter is typed.  Use the String {@code "<caret>"} in your
+     * 'before' and 'expected' arguments to indicate the position of the caret in those strings.
+     *
+     * @param before The text before Enter typed, with substring "<caret>" to indicate the position of the caret
+     * @param expected The text after Enter is typed, with substring "<caret>" to indicate the position of the caret
+     */
+    protected void doEnterTest(@NotNull String before, @NotNull String expected) {
+        validateTestStrings(before, expected);
+
+        myFixture.configureByText(HbFileType.INSTANCE, before);
+        final EditorActionHandler enterActionHandler = EditorActionManager.getInstance().getActionHandler(IdeActions.ACTION_EDITOR_ENTER);
+        performWriteAction(myFixture.getProject(), new Runnable() {
+            @Override
+            public void run() {
+                enterActionHandler.execute(myFixture.getEditor(), ((EditorEx) myFixture.getEditor()).getDataContext());
+            }
+        });
+        myFixture.checkResult(expected);
+    }
+}

--- a/test/src/com/dmarcotte/handlebars/editor/actions/HbEnterHandlerTest.java
+++ b/test/src/com/dmarcotte/handlebars/editor/actions/HbEnterHandlerTest.java
@@ -1,0 +1,72 @@
+package com.dmarcotte.handlebars.editor.actions;
+
+public class HbEnterHandlerTest extends HbActionHandlerTest {
+
+    /**
+     * On Enter between matching open/close tags,
+     * expect an extra newline to be inserted with the caret placed
+     * between the tags
+     */
+    public void testEnterBetweenMatchingHbTags() {
+        doEnterTest(
+
+                "{{#foo}}<caret>{{/foo}}",
+
+                "{{#foo}}\n" +
+                "<caret>\n" +
+                "{{/foo}}"
+        );
+    }
+
+    /**
+     * On Enter between MIS-matched open/close tags,
+     * expect a standard newline
+     */
+    public void testEnterBetweenMismatchedHbTags() {
+        doEnterTest(
+
+                "{{#foo}}<caret>{{/bar}}" +
+                "stuff",
+
+                "{{#foo}}\n" +
+                "<caret>{{/bar}}" +
+                "stuff"
+        );
+    }
+
+    /**
+     * On Enter at an open tag with no close tag,
+     * expect a standard newline
+     * (Notice that we have "other stuff" our test string.  When the caret is at the file
+     * boundary, it's actually a special case.  See {@link #testEnterAtOpenTagOnFileBoundary}
+     */
+    public void testEnterAtOpenTag() {
+        doEnterTest(
+
+                "{{#foo}}<caret>" +
+                "other stuff",
+
+                "{{#foo}}\n" +
+                "<caret>" +
+                "other stuff"
+
+        );
+    }
+
+    /**
+     * On Enter at an open tag with no close tag,
+     * expect a standard newline.
+     *
+     * Note: this used to result in an error.  The was a bug where we checked beyond the
+     * end of the file for a close tag to go with this open tag.
+     */
+    public void testEnterAtOpenTagOnFileBoundary() {
+        doEnterTest(
+
+                "{{#foo}}<caret>",
+
+                "{{#foo}}\n" +
+                "<caret>"
+        );
+    }
+}

--- a/test/src/com/dmarcotte/handlebars/editor/actions/HbTypedHandlerTest.java
+++ b/test/src/com/dmarcotte/handlebars/editor/actions/HbTypedHandlerTest.java
@@ -1,15 +1,6 @@
 package com.dmarcotte.handlebars.editor.actions;
 
 import com.dmarcotte.handlebars.config.HbConfig;
-import com.dmarcotte.handlebars.file.HbFileType;
-import com.intellij.openapi.application.ApplicationManager;
-import com.intellij.openapi.command.CommandProcessor;
-import com.intellij.openapi.editor.actionSystem.EditorActionManager;
-import com.intellij.openapi.editor.actionSystem.TypedAction;
-import com.intellij.openapi.editor.ex.EditorEx;
-import com.intellij.openapi.project.Project;
-import com.intellij.testFramework.fixtures.LightPlatformCodeInsightFixtureTestCase;
-import org.jetbrains.annotations.NotNull;
 
 
 /**
@@ -18,85 +9,70 @@ import org.jetbrains.annotations.NotNull;
  *
  * TODO this test cannot be run with our others due to some interdependency in the IDEA base tests.  Fix this or organize the code in such a way that it is clear these cannot be run together
  */
-public class HbTypedHandlerTest extends LightPlatformCodeInsightFixtureTestCase {
+public class HbTypedHandlerTest extends HbActionHandlerTest {
 
     private boolean myPrevAutoCloseSetting;
-    private String myPrevPlatformPrefix;
-
-    private void performWriteAction(final Project project, final Runnable action) {
-        ApplicationManager.getApplication().runWriteAction(new Runnable() {
-            @Override
-            public void run() {
-                CommandProcessor.getInstance().executeCommand(project, action, "test command", null);
-            }
-        });
-    }
 
     @Override
     protected void setUp() throws Exception {
-        // this test's parent setup requires that this property be set
-        myPrevPlatformPrefix = System.getProperty("idea.platform.prefix");
-        System.setProperty("idea.platform.prefix", "Idea");
-
         super.setUp();
         myPrevAutoCloseSetting = HbConfig.isAutoGenerateCloseTagEnabled();
     }
 
     @Override
     protected void tearDown() throws Exception {
-        HbConfig.setAutoGenerateCloseTagEnabled(myPrevAutoCloseSetting);
-        if (myPrevPlatformPrefix == null) {
-            System.setProperty("idea.platform.prefix", "");
-        } else {
-            System.setProperty("idea.platform.prefix", myPrevPlatformPrefix);
-        }
         super.tearDown();
-    }
-
-    private void doTest(final char c, @NotNull String before, @NotNull String expected) {
-        myFixture.configureByText(HbFileType.INSTANCE, before);
-        myFixture.getEditor().getCaretModel().moveToOffset(before.length());
-        final TypedAction typedAction = EditorActionManager.getInstance().getTypedAction();
-        performWriteAction(myFixture.getProject(), new Runnable() {
-            @Override
-            public void run() {
-                typedAction.actionPerformed(myFixture.getEditor(), c, ((EditorEx) myFixture.getEditor()).getDataContext());
-            }
-        });
-        myFixture.checkResult(expected);
+        HbConfig.setAutoGenerateCloseTagEnabled(myPrevAutoCloseSetting);
     }
 
     public void testOpenBlockStache() {
         HbConfig.setAutoGenerateCloseTagEnabled(true);
-        doTest('}', "{{#foo}", "{{#foo}}{{/foo}}");
-        doTest('}', "{{#foo bar baz}", "{{#foo bar baz}}{{/foo}}");
-        doTest('}', "{{#foo bar baz bat=\"bam\"}", "{{#foo bar baz bat=\"bam\"}}{{/foo}}");
+        doCharTest('}', "{{#foo}<caret>", "{{#foo}}<caret>{{/foo}}");
+        doCharTest('}', "{{#foo bar baz}<caret>", "{{#foo bar baz}}<caret>{{/foo}}");
+        doCharTest('}', "{{#foo bar baz bat=\"bam\"}<caret>", "{{#foo bar baz bat=\"bam\"}}<caret>{{/foo}}");
+
+        // test when caret is not at file boundary
+        doCharTest('}', "{{#foo}<caret>some\nother content", "{{#foo}}<caret>{{/foo}}some\nother content");
+        doCharTest('}', "{{#foo bar baz}<caret>some\nother content", "{{#foo bar baz}}<caret>{{/foo}}some\nother content");
+        doCharTest('}', "{{#foo bar baz bat=\"bam\"}<caret>some\nother content", "{{#foo bar baz bat=\"bam\"}}<caret>{{/foo}}some\nother content");
 
         HbConfig.setAutoGenerateCloseTagEnabled(false);
-        doTest('}', "{{#foo}", "{{#foo}}");
-        doTest('}', "{{#foo bar baz}", "{{#foo bar baz}}");
-        doTest('}', "{{#foo bar baz bat=\"bam\"}", "{{#foo bar baz bat=\"bam\"}}");
+        doCharTest('}', "{{#foo}<caret>", "{{#foo}}<caret>");
+        doCharTest('}', "{{#foo bar baz}<caret>", "{{#foo bar baz}}<caret>");
+        doCharTest('}', "{{#foo bar baz bat=\"bam\"}<caret>", "{{#foo bar baz bat=\"bam\"}}<caret>");
     }
 
     public void testOpenInverseStache(){
         HbConfig.setAutoGenerateCloseTagEnabled(true);
-        doTest('}', "{{^foo}", "{{^foo}}{{/foo}}");
-        doTest('}', "{{^foo bar baz}", "{{^foo bar baz}}{{/foo}}");
-        doTest('}', "{{^foo bar baz bat=\"bam\"}", "{{^foo bar baz bat=\"bam\"}}{{/foo}}");
+        doCharTest('}', "{{^foo}<caret>", "{{^foo}}<caret>{{/foo}}");
+        doCharTest('}', "{{^foo bar baz}<caret>", "{{^foo bar baz}}<caret>{{/foo}}");
+        doCharTest('}', "{{^foo bar baz bat=\"bam\"}<caret>", "{{^foo bar baz bat=\"bam\"}}<caret>{{/foo}}");
+
+        // test when caret is not at file boundary
+        doCharTest('}', "{{^foo}<caret>some\nother content", "{{^foo}}<caret>{{/foo}}some\nother content");
+        doCharTest('}', "{{^foo bar baz}<caret>some\nother content", "{{^foo bar baz}}<caret>{{/foo}}some\nother content");
+        doCharTest('}', "{{^foo bar baz bat=\"bam\"}<caret>some\nother content", "{{^foo bar baz bat=\"bam\"}}<caret>{{/foo}}some\nother content");
 
         HbConfig.setAutoGenerateCloseTagEnabled(false);
-        doTest('}', "{{^foo}", "{{^foo}}");
-        doTest('}', "{{^foo bar baz}", "{{^foo bar baz}}");
-        doTest('}', "{{^foo bar baz bat=\"bam\"}", "{{^foo bar baz bat=\"bam\"}}");
+        doCharTest('}', "{{^foo}<caret>", "{{^foo}}<caret>");
+        doCharTest('}', "{{^foo bar baz}<caret>", "{{^foo bar baz}}<caret>");
+        doCharTest('}', "{{^foo bar baz bat=\"bam\"}<caret>", "{{^foo bar baz bat=\"bam\"}}<caret>");
     }
 
     public void testRegularStache() {
+        // ensure that nothing special happens for regular 'staches, whether autoGenerateCloseTag is enabled or not
+        
         HbConfig.setAutoGenerateCloseTagEnabled(true);
-        doTest('}', "{{foo}", "{{foo}}");
-        doTest('}', "{{foo bar baz}", "{{foo bar baz}}");
+        doCharTest('}', "{{foo}<caret>", "{{foo}}<caret>");
+        doCharTest('}', "{{foo bar baz}<caret>", "{{foo bar baz}}<caret>");
+
+        // test when caret is not at file boundary
+        HbConfig.setAutoGenerateCloseTagEnabled(true);
+        doCharTest('}', "{{foo}<caret>some\nother stuff", "{{foo}}<caret>some\nother stuff");
+        doCharTest('}', "{{foo bar baz}<caret>some\nother stuff", "{{foo bar baz}}<caret>some\nother stuff");
 
         HbConfig.setAutoGenerateCloseTagEnabled(false);
-        doTest('}', "{{foo}", "{{foo}}");
-        doTest('}', "{{foo bar baz}", "{{foo bar baz}}");
+        doCharTest('}', "{{foo}<caret>", "{{foo}}<caret>");
+        doCharTest('}', "{{foo bar baz}<caret>", "{{foo bar baz}}<caret>");
     }
 }


### PR DESCRIPTION
The Handler which was in charge of smartly inserting an extra newline between open and close block tags errors in the following situation: the caret is at the end of file immediately following an open block expression.  i.e.

```
{{#foo}}<caret><EOF>
```

This pull fixes that issue and refactors action handler tests to be more awesome.

Here's the stack for the error described above:

```
Error during dispatching of java.awt.event.KeyEvent[KEY_PRESSED,keyCode=10,keyText=⏎,keyChar=⏎,keyLocation=KEY_LOCATION_STANDARD,rawCode=0,primaryLevelUnicode=0,scancode=0] on frame13: Wrong line: 7. Available lines count: 7
java.lang.IndexOutOfBoundsException: Wrong line: 7. Available lines count: 7
    at com.intellij.openapi.editor.ex.util.SegmentArray.getSegmentStart(SegmentArray.java:266)
    at com.intellij.openapi.editor.ex.util.LexerEditorHighlighter$HighlighterIteratorImpl.getStart(LexerEditorHighlighter.java:373)
    at com.intellij.openapi.editor.ex.util.LayeredLexerEditorHighlighter$LayeredHighlighterIterator.getStart(LayeredLexerEditorHighlighter.java:510)
    at com.dmarcotte.handlebars.editor.actions.HbEnterBetweenTagsHandler.isBetweenHbTags(HbEnterBetweenTagsHandler.java:45)
    at com.dmarcotte.handlebars.editor.actions.HbEnterBetweenTagsHandler.preprocessEnter(HbEnterBetweenTagsHandler.java:20)
    at com.intellij.codeInsight.editorActions.EnterHandler.a(EnterHandler.java:122)
    at com.intellij.codeInsight.editorActions.EnterHandler.access$000(EnterHandler.java:53)
    at com.intellij.codeInsight.editorActions.EnterHandler$1.run(EnterHandler.java:71)
    at com.intellij.psi.impl.source.PostprocessReformattingAspect$2.compute(PostprocessReformattingAspect.java:101)
    at com.intellij.psi.impl.source.PostprocessReformattingAspect.disablePostprocessFormattingInside(PostprocessReformattingAspect.java:110)
    at com.intellij.psi.impl.source.PostprocessReformattingAspect.disablePostprocessFormattingInside(PostprocessReformattingAspect.java:98)
    at com.intellij.codeInsight.editorActions.EnterHandler.executeWriteAction(EnterHandler.java:69)
    at com.intellij.openapi.editor.actionSystem.EditorWriteActionHandler$1.run(EditorWriteActionHandler.java:52)
    at com.intellij.openapi.application.impl.ApplicationImpl.runWriteAction(ApplicationImpl.java:902)
    at com.intellij.openapi.editor.actionSystem.EditorWriteActionHandler.execute(EditorWriteActionHandler.java:36)
    at com.intellij.codeInsight.template.impl.editorActions.EnterHandler.executeWriteAction(EnterHandler.java:51)
    at com.intellij.openapi.editor.actionSystem.EditorWriteActionHandler$1.run(EditorWriteActionHandler.java:52)
    at com.intellij.openapi.application.impl.ApplicationImpl.runWriteAction(ApplicationImpl.java:902)
    at com.intellij.openapi.editor.actionSystem.EditorWriteActionHandler.execute(EditorWriteActionHandler.java:36)
    at com.intellij.openapi.editor.actionSystem.EditorAction$1.run(EditorAction.java:82)
    at com.intellij.openapi.command.impl.CommandProcessorImpl.executeCommand(CommandProcessorImpl.java:117)
    at com.intellij.openapi.editor.actionSystem.EditorAction.actionPerformed(EditorAction.java:93)
    at com.intellij.openapi.editor.actionSystem.EditorAction.actionPerformed(EditorAction.java:67)
    at com.intellij.openapi.keymap.impl.IdeKeyEventDispatcher$3.performAction(IdeKeyEventDispatcher.java:542)
    at com.intellij.openapi.keymap.impl.IdeKeyEventDispatcher.processAction(IdeKeyEventDispatcher.java:590)
    at com.intellij.openapi.keymap.impl.IdeKeyEventDispatcher.d(IdeKeyEventDispatcher.java:458)
    at com.intellij.openapi.keymap.impl.IdeKeyEventDispatcher.dispatchKeyEvent(IdeKeyEventDispatcher.java:206)
    at com.intellij.ide.IdeEventQueue._dispatchEvent(IdeEventQueue.java:524)
    at com.intellij.ide.IdeEventQueue.b(IdeEventQueue.java:420)
    at com.intellij.ide.IdeEventQueue.dispatchEvent(IdeEventQueue.java:378)
    at java.awt.EventDispatchThread.pumpOneEventForFilters(EventDispatchThread.java:296)
    at java.awt.EventDispatchThread.pumpEventsForFilter(EventDispatchThread.java:211)
    at java.awt.EventDispatchThread.pumpEventsForHierarchy(EventDispatchThread.java:201)
    at java.awt.EventDispatchThread.pumpEvents(EventDispatchThread.java:196)
    at java.awt.EventDispatchThread.pumpEvents(EventDispatchThread.java:188)
    at java.awt.EventDispatchThread.run(EventDispatchThread.java:122)
```
