### PR TITLE
Allow selection of Handlebars Commenter for comment actions

### DIFF
--- a/META-INF/plugin.xml
+++ b/META-INF/plugin.xml
@@ -168,7 +168,7 @@
     <lang.formatter language="Handlebars" implementationClass="com.dmarcotte.handlebars.format.HbFormattingModelBuilder"/>
     <colorSettingsPage implementation="com.dmarcotte.handlebars.pages.HbColorsPage"/>
     <lang.fileViewProviderFactory language="Handlebars" implementationClass="com.dmarcotte.handlebars.file.HbFileViewProviderFactory"/>
-    <lang.commenter language="Handlebars" implementationClass="com.dmarcotte.handlebars.HandlebarsCommenter"/>
+    <lang.commenter language="Handlebars" implementationClass="com.dmarcotte.handlebars.editor.comments.HbCommenter"/>
     <lang.braceMatcher language="Handlebars" implementationClass="com.dmarcotte.handlebars.HbBraceMatcher"/>
     <lang.foldingBuilder language="Handlebars"
                          implementationClass="com.dmarcotte.handlebars.editor.folding.HbFoldingBuilder" />

--- a/src/com/dmarcotte/handlebars/config/HbConfig.java
+++ b/src/com/dmarcotte/handlebars/config/HbConfig.java
@@ -41,7 +41,11 @@ public class HbConfig {
     }
 
     public static void setCommenterLanguage(Language language) {
-        setStringPropertyValue(COMMENTER_LANGUAGE_ID, language.getID());
+        if (language == null) {
+            setStringPropertyValue(COMMENTER_LANGUAGE_ID, null);
+        } else {
+            setStringPropertyValue(COMMENTER_LANGUAGE_ID, language.getID());
+        }
     }
 
     private static String getStringPropertyValue(Property property) {

--- a/src/com/dmarcotte/handlebars/editor/comments/HandlebarsCommenter.java
+++ b/src/com/dmarcotte/handlebars/editor/comments/HandlebarsCommenter.java
@@ -1,0 +1,39 @@
+package com.dmarcotte.handlebars.editor.comments;
+
+import com.intellij.lang.Commenter;
+import org.jetbrains.annotations.Nullable;
+
+/**
+ * Commenter for native Handlebars comments: <pre>{{!-- comment --}}</pre>
+ */
+public class HandlebarsCommenter implements Commenter {
+    @Nullable
+    @Override
+    public String getLineCommentPrefix() {
+        return null;
+    }
+
+    @Nullable
+    @Override
+    public String getBlockCommentPrefix() {
+        return "{{!--";
+    }
+
+    @Nullable
+    @Override
+    public String getBlockCommentSuffix() {
+        return "--}}";
+    }
+
+    @Nullable
+    @Override
+    public String getCommentedBlockCommentPrefix() {
+        return null;
+    }
+
+    @Nullable
+    @Override
+    public String getCommentedBlockCommentSuffix() {
+        return null;
+    }
+}

--- a/src/com/dmarcotte/handlebars/editor/comments/HbCommenter.java
+++ b/src/com/dmarcotte/handlebars/editor/comments/HbCommenter.java
@@ -1,12 +1,16 @@
-package com.dmarcotte.handlebars;
+package com.dmarcotte.handlebars.editor.comments;
 
+import com.dmarcotte.handlebars.HbLanguage;
 import com.dmarcotte.handlebars.config.HbConfig;
 import com.intellij.lang.Commenter;
 import com.intellij.lang.Language;
 import com.intellij.lang.LanguageCommenters;
 import org.jetbrains.annotations.Nullable;
 
-public class HandlebarsCommenter implements Commenter {
+public class HbCommenter implements Commenter {
+
+    private static Commenter ourHandlebarsCommenter = new HandlebarsCommenter();
+
     @Nullable
     @Override
     public String getLineCommentPrefix() {
@@ -41,7 +45,10 @@ public class HandlebarsCommenter implements Commenter {
         Language commenterLanguage = HbConfig.getCommenterLanguage();
         if (commenterLanguage == null) {
             commenterLanguage = HbLanguage.getDefaultTemplateLang().getLanguage();
+        } else if (commenterLanguage.getID().equals(HbLanguage.INSTANCE.getID())) {
+            return ourHandlebarsCommenter;
         }
+
         return LanguageCommenters.INSTANCE.forLanguage(commenterLanguage);
     }
 }

--- a/src/com/dmarcotte/handlebars/pages/HbConfigurationPage.java
+++ b/src/com/dmarcotte/handlebars/pages/HbConfigurationPage.java
@@ -1,6 +1,7 @@
 package com.dmarcotte.handlebars.pages;
 
 import com.dmarcotte.handlebars.HbBundle;
+import com.dmarcotte.handlebars.HbLanguage;
 import com.dmarcotte.handlebars.config.HbConfig;
 import com.intellij.ide.ui.ListCellRendererWrapper;
 import com.intellij.lang.Language;
@@ -85,6 +86,10 @@ public class HbConfigurationPage implements SearchableConfigurable {
     private void resetCommentLanguageCombo(Language commentLanguage) {
         final DefaultComboBoxModel model = (DefaultComboBoxModel) myCommenterLanguage.getModel();
         final List<Language> languages = TemplateDataLanguageMappings.getTemplateableLanguages();
+
+        // add using the native Handlebars commenter as an option
+        languages.add(HbLanguage.INSTANCE);
+
         Collections.sort(languages, new Comparator<Language>() {
             @Override
             public int compare(final Language o1, final Language o2) {

--- a/test/src/com/dmarcotte/handlebars/editor/actions/HbCommentActionTest.java
+++ b/test/src/com/dmarcotte/handlebars/editor/actions/HbCommentActionTest.java
@@ -1,8 +1,8 @@
 package com.dmarcotte.handlebars.editor.actions;
 
+import com.dmarcotte.handlebars.HbLanguage;
 import com.dmarcotte.handlebars.config.HbConfig;
 import com.intellij.lang.Language;
-import com.intellij.lang.html.HTMLLanguage;
 import com.intellij.lang.java.JavaLanguage;
 
 public class HbCommentActionTest extends HbActionHandlerTest {
@@ -15,7 +15,9 @@ public class HbCommentActionTest extends HbActionHandlerTest {
         super.setUp();
 
         myPrevCommenterLang = HbConfig.getCommenterLanguage();
-        HbConfig.setCommenterLanguage(HTMLLanguage.INSTANCE);
+
+        // ensure that no commenter is selected to make sure that we test defaulting to HTML comments
+        HbConfig.setCommenterLanguage(null);
     }
 
     public void testInsertLineComment1() {
@@ -101,6 +103,88 @@ public class HbCommentActionTest extends HbActionHandlerTest {
         );
 
         HbConfig.setCommenterLanguage(prevCommenterLanguage);
+    }
+
+    public void testNativeInsertLineComment1() {
+        Language prevCommenterLang = HbConfig.getCommenterLanguage();
+        HbConfig.setCommenterLanguage(HbLanguage.INSTANCE);
+
+        doLineCommentTest(
+
+                "{{#foo}}<caret>",
+
+                "{{!--{{#foo}}<caret>--}}"
+        );
+
+        HbConfig.setCommenterLanguage(prevCommenterLang);
+    }
+
+    public void testNativeInsertLineComment2() {
+        Language prevCommenterLang = HbConfig.getCommenterLanguage();
+        HbConfig.setCommenterLanguage(HbLanguage.INSTANCE);
+
+        doLineCommentTest(
+
+                "{{#foo}}\n" +
+                "<caret>    {{bar}}\n" +
+                "{{/foo}}",
+
+                "{{#foo}}\n" +
+                "    {{!--{{bar}}--}}\n" +
+                "<caret>{{/foo}}"
+        );
+
+        HbConfig.setCommenterLanguage(prevCommenterLang);
+    }
+
+    public void testNativeInsertBlockComment1() {
+        Language prevCommenterLang = HbConfig.getCommenterLanguage();
+        HbConfig.setCommenterLanguage(HbLanguage.INSTANCE);
+
+        doBlockCommentTest(
+
+                "{{#foo}}<caret>",
+
+                "{{#foo}}{{!--<caret>--}}"
+        );
+
+        HbConfig.setCommenterLanguage(prevCommenterLang);
+    }
+
+    public void testNativeInsertBlockComment2() {
+        Language prevCommenterLang = HbConfig.getCommenterLanguage();
+        HbConfig.setCommenterLanguage(HbLanguage.INSTANCE);
+
+        doBlockCommentTest(
+
+                "{{#foo}}\n" +
+                "    <caret>{{bar}}\n" +
+                "{{/foo}",
+
+                "{{#foo}}\n" +
+                "    {{!--<caret>--}}{{bar}}\n" +
+                "{{/foo}"
+        );
+
+        HbConfig.setCommenterLanguage(prevCommenterLang);
+    }
+
+    public void testNativeInsertBlockCommentWithSelection() {
+        Language prevCommenterLang = HbConfig.getCommenterLanguage();
+        HbConfig.setCommenterLanguage(HbLanguage.INSTANCE);
+
+        doBlockCommentTest(
+
+                "<selection><caret>{{#foo}}" +
+                "    {{bar}}</selection>" +
+                "{{/foo}",
+
+                "<selection>{{!--<caret>{{#foo}}" +
+                "    {{bar}}--}}</selection>" +
+                "{{/foo}"
+        );
+
+        HbConfig.setCommenterLanguage(prevCommenterLang);
     }
 
     @Override


### PR DESCRIPTION
If you are using a recent version of Handlebars which supports the new block comment construct (`{{!-- comment --}}`), you can select that commenter for use by the "Comment with Line Comment" and "Comment with Block Comment" actions in all Handlebars files. 

Select "Handlebars" for **Language for comments** in `Settings->Handlebars/Mustache` to enable.
