### PR TITLE
Add folding for both block and standard comments

### DIFF
--- a/src/com/dmarcotte/handlebars/editor/folding/HbFoldingBuilder.java
+++ b/src/com/dmarcotte/handlebars/editor/folding/HbFoldingBuilder.java
@@ -31,6 +31,19 @@ public class HbFoldingBuilder implements FoldingBuilder, DumbAware {
             return;
         }
 
+        if (HbTokenTypes.COMMENT == node.getElementType()) {
+            String commentText = node.getText();
+
+            // comment might be unclosed, so do a bit of sanity checking on its length and whether or not it's
+            // got the requisite open/close tags before we allow folding
+            if (commentText.length() > 5
+                    && commentText.substring(0,3).equals("{{!")
+                    && commentText.substring(commentText.length() - 2, commentText.length()).equals("}}")) {
+                TextRange range = new TextRange(node.getTextRange().getStartOffset() + 3, node.getTextRange().getEndOffset() -2);
+                descriptors.add(new FoldingDescriptor(node, range));
+            }
+        }
+
         if (HbTokenTypes.BLOCK_WRAPPER == node.getElementType()) {
 
             ASTNode endOpenBlockStache = getOpenBlockCloseStacheElement(node.getFirstChildNode());

--- a/test/data/folding/commentFolds.hbs
+++ b/test/data/folding/commentFolds.hbs
@@ -1,0 +1,20 @@
+{{! this is a one line comment }}
+{{!-- this is a one line block comment --}}
+
+{{!<fold text='...'>
+    this is a multi-line comment
+</fold>}}
+
+{{!<fold text='...'>--
+    {{#foo}}
+        {{bar}}
+        <ul>
+            <li>
+
+            </li>
+        </ul>
+    {{/foo}}
+--</fold>}}
+
+{{!
+    this is an unclosed comment

--- a/test/src/com/dmarcotte/handlebars/editor/folding/HbFoldingBuilderTest.java
+++ b/test/src/com/dmarcotte/handlebars/editor/folding/HbFoldingBuilderTest.java
@@ -18,6 +18,7 @@ public class HbFoldingBuilderTest extends LightPlatformCodeInsightFixtureTestCas
     public void testMultipleFolds() { doTest(); }
     public void testSloppyEndBlockFolds() { doTest(); }
     public void testUnclosedOpenStache() { doTest(); }
+    public void testCommentFolds() { doTest(); }
 
     /**
      * Test folding based by validating against a the file in {@link #TEST_DATA_PATH} who


### PR DESCRIPTION
Enables folding on multiline comments for both 

```
{{! 
   mustache comments
}}
```

and 

```
{{!-- 
    handlebars block comments 
--}}
```
