### PR TITLE
Fix brace matching for simple inverses

### DIFF
--- a/src/com/dmarcotte/handlebars/editor/braces/HbBraceMatcher.java
+++ b/src/com/dmarcotte/handlebars/editor/braces/HbBraceMatcher.java
@@ -55,11 +55,28 @@ public class HbBraceMatcher implements BraceMatcher {
                 break;
             }
 
-            if (iterator.getTokenType() == HbTokenTypes.OPEN_BLOCK
-                    || iterator.getTokenType() == HbTokenTypes.OPEN_INVERSE) {
+            if (iterator.getTokenType() == HbTokenTypes.OPEN_BLOCK) {
                 // the first open type token we encountered is a block opener,
                 // so this is not a close brace (the paired close brace for these tokens
                 // is at the end of the corresponding block close 'stache)
+                break;
+            }
+
+            if (iterator.getTokenType() == HbTokenTypes.OPEN_INVERSE) {
+                // this might be a simple inverse, so backtrack until we either see
+                // and ID (which means we're in a situation like OPEN_BLOCK above)
+                // or a CLOSE (which means we're a simple inverse, and this is the RBrace)
+                while (iteratorRetreatCount-- > 0) {
+                    iterator.advance();
+                    if (iterator.getTokenType() == HbTokenTypes.ID) {
+                        break;
+                    }
+
+                    if (iterator.getTokenType() == HbTokenTypes.CLOSE) {
+                        isRBraceToken = true;
+                        break;
+                    }
+                }
                 break;
             }
 

--- a/test/src/com/dmarcotte/handlebars/editor/braces/HbBraceMatcherTest.java
+++ b/test/src/com/dmarcotte/handlebars/editor/braces/HbBraceMatcherTest.java
@@ -84,8 +84,9 @@ public class HbBraceMatcherTest extends LightPlatformCodeInsightFixtureTestCase 
      *       by string replace functions.
      */
     private static String ourTestSource =
-            "{{# foo }}\n" +
+            "{{# foo1 }}\n" +
             "    {{ bar }}\n" +
+            "    {{^ }}\n" +
             "    {{# foo2 }}\n" +
             "        <div>\n" +
             "            {{^ foo3 }}\n" +
@@ -96,7 +97,12 @@ public class HbBraceMatcherTest extends LightPlatformCodeInsightFixtureTestCase 
             "        {{ bat }}\n" +
             "        {{> partial }}\n" +
             "    {{/ foo2 }}\n" +
-            "{{/ foo }}";
+            "{{/ foo1 }}\n" +
+            "\n" +
+            "{{^ foo4 }}\n" +
+            "    Content\n" +
+            "{{/ foo4 }}\n"
+            ;
 
     public void testSimpleMustache() {
         doBraceTest(
@@ -121,8 +127,22 @@ public class HbBraceMatcherTest extends LightPlatformCodeInsightFixtureTestCase 
 
     public void testBlockMustache() {
         doBraceTest(
-                ourTestSource.replace("{{# foo }}", "<brace_match>{{# foo }}")
-                        .replace("{{/ foo }}", "{{/ foo <brace_match>}}")
+                ourTestSource.replace("{{# foo1 }}", "<brace_match>{{# foo1 }}")
+                        .replace("{{/ foo1 }}", "{{/ foo1 <brace_match>}}")
+        );
+    }
+
+    public void testInverseBlockMustache() {
+        doBraceTest(
+                ourTestSource.replace("{{^ foo4 }}", "<brace_match>{{^ foo4 }}")
+                        .replace("{{/ foo4 }}", "{{/ foo4 <brace_match>}}")
+        );
+    }
+
+    public void testSimpleInverseMustache() {
+        doBraceTest(
+                ourTestSource.replace("{{^ }}", "<brace_match>{{^ }}")
+                        .replace("{{^ }}", "{{^ <brace_match>}}")
         );
     }
 


### PR DESCRIPTION
The brace matching added in #51 was treating simple inverses as if they were inverse block open blocks, which was messing up matching.
