### PR TITLE
Implementation of Line Marker for file navigation

### DIFF
--- a/META-INF/plugin.xml
+++ b/META-INF/plugin.xml
@@ -223,5 +223,6 @@
     <applicationConfigurable instance="com.dmarcotte.handlebars.pages.HbConfigurationPage"/>
     <codeFoldingOptionsProvider
         instance="com.dmarcotte.handlebars.config.HbFoldingOptionsProvider" />
+      <codeInsight.lineMarkerProvider language="Handlebars" implementationClass="com.dmarcotte.handlebars.editor.lines.HbLineMarkerProvider"/>
   </extensions>
 </idea-plugin>

--- a/resources/messages/HbBundle.properties
+++ b/resources/messages/HbBundle.properties
@@ -42,3 +42,4 @@ hb.pages.folding.auto.collapse.blocks=Handlebars/Mustache blocks
 hb.page.options.commenter.language=&Language for comments\:
 hb.page.options.commenter.language.tooltip=Controls which language's comment syntax to use for "Comment with Block Comment" and "Comment with Line Comment" actions
 hb.parsing.comment.unclosed=Unclosed comment
+hb.editor.lines.tooltip=Navigate to partial

--- a/src/com/dmarcotte/handlebars/editor/lines/HbLineMarkerProvider.java
+++ b/src/com/dmarcotte/handlebars/editor/lines/HbLineMarkerProvider.java
@@ -1,0 +1,43 @@
+package com.dmarcotte.handlebars.editor.lines;
+
+import com.dmarcotte.handlebars.HbBundle;
+import com.dmarcotte.handlebars.file.HbFileType;
+import com.dmarcotte.handlebars.file.HbFileUtil;
+import com.dmarcotte.handlebars.parsing.HbTokenTypes;
+import com.dmarcotte.handlebars.psi.HbPsiElement;
+import com.dmarcotte.handlebars.psi.HbPsiFile;
+import com.intellij.codeInsight.daemon.RelatedItemLineMarkerInfo;
+import com.intellij.codeInsight.daemon.RelatedItemLineMarkerProvider;
+import com.intellij.codeInsight.navigation.NavigationGutterIconBuilder;
+import com.intellij.openapi.project.Project;
+import com.intellij.psi.PsiElement;
+import com.intellij.psi.PsiFile;
+import com.intellij.psi.tree.IElementType;
+import org.jetbrains.annotations.NotNull;
+
+import java.util.Collection;
+import java.util.List;
+
+public class HbLineMarkerProvider extends RelatedItemLineMarkerProvider {
+	@Override
+	protected void collectNavigationMarkers(@NotNull PsiElement element, Collection<? super RelatedItemLineMarkerInfo> result) {
+		if (element instanceof HbPsiElement) {
+			HbPsiElement hbElement = (HbPsiElement) element;
+			IElementType nodeType = hbElement.getNode().getElementType();
+			if (nodeType == HbTokenTypes.PARTIAL_NAME) {
+				String fileName = hbElement.getText();
+				Project project = element.getProject();
+				PsiFile currentFile = hbElement.getContainingFile();
+				String fileExtension = currentFile.getName().split("\\.")[1];
+				final List<HbPsiFile> properties = HbFileUtil.findFiles(project, fileName+"."+fileExtension);
+				if (properties.size() > 0) {
+					NavigationGutterIconBuilder<PsiElement> builder =
+							NavigationGutterIconBuilder.create(HbFileType.FILE_ICON).
+									setTargets(properties).
+									setTooltipText(HbBundle.message("hb.editor.lines.tooltip"));
+					result.add(builder.createLineMarkerInfo(element));
+				}
+			}
+		}
+	}
+}

--- a/src/com/dmarcotte/handlebars/file/HbFileUtil.java
+++ b/src/com/dmarcotte/handlebars/file/HbFileUtil.java
@@ -1,0 +1,44 @@
+package com.dmarcotte.handlebars.file;
+
+import com.intellij.openapi.project.Project;
+import com.intellij.openapi.vfs.VirtualFile;
+import com.intellij.psi.PsiManager;
+import com.intellij.psi.search.FileTypeIndex;
+import com.intellij.psi.search.GlobalSearchScope;
+import com.intellij.util.indexing.FileBasedIndex;
+import com.dmarcotte.handlebars.psi.HbPsiFile;
+
+import java.util.ArrayList;
+import java.util.Collection;
+import java.util.Collections;
+import java.util.List;
+
+public class HbFileUtil {
+	public static List<HbPsiFile> findFiles(Project project, String key) {
+		List<HbPsiFile> result = new ArrayList<HbPsiFile>();
+		Collection<VirtualFile> virtualFiles = FileBasedIndex.getInstance().getContainingFiles(FileTypeIndex.NAME, HbFileType.INSTANCE,
+				GlobalSearchScope.allScope(project));
+		for (VirtualFile virtualFile : virtualFiles) {
+			HbPsiFile hbFile = (HbPsiFile) PsiManager.getInstance(project).findFile(virtualFile);
+			if (hbFile != null) {
+				if (hbFile.getName().matches(key)) {
+					result.add(hbFile);
+				}
+			}
+		}
+		return result;
+	}
+
+	public static List<HbPsiFile> findFiles(Project project) {
+		List<HbPsiFile> result = new ArrayList<HbPsiFile>();
+		Collection<VirtualFile> virtualFiles = FileBasedIndex.getInstance().getContainingFiles(FileTypeIndex.NAME, HbFileType.INSTANCE,
+				GlobalSearchScope.allScope(project));
+		for (VirtualFile virtualFile : virtualFiles) {
+			HbPsiFile hbFile = (HbPsiFile) PsiManager.getInstance(project).findFile(virtualFile);
+			if (hbFile != null) {
+				Collections.addAll(result, hbFile);
+			}
+		}
+		return result;
+	}
+}


### PR DESCRIPTION
This adds a line marker provider which reads partial staches like {{> test}}
and will try to find a file that matches. If it does the line gets a
mustache in the gutter that when clicked either leads to the file or lists
possible matches.

I just implemented this for my plugin and finally saw my chance to give back. I'm not sure how much this feature is used in your case but it's been frequently requested in my plugin so I ported it to your plugin as well.

I'm making a couple of assumptions that I'm not sure about. Namely
- The file ending should match the file ending of the current file
- The file search searches the whole project for a file match
  I don't know how Mustache handles where to look for partials so if it only searches certain folders/sub folders then this might need some reworking. Also figuring out the file ending is right now a major PHPism (PHP MAD REPRESENT!). 

The only method I found for getting the file extension was FileType.getDefaultExtension() and that will in your case return "handlebars;hbs;mustache" which is pretty useless in this case. To solve this I end up splitting the full file name via getName() which feels like a very PHP way of doing things and not really the right way. However I often find the classes I'm reading through lacking expected method (like why only Marker.precede and not Marker.wrap?).

Anyway let me know what you think. I'm ready to change/fix/whatever you need in this.
